### PR TITLE
Copy def properties to Hydra Classes

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -157,11 +157,11 @@ hydra.Document = function (api, def, iri) {
 hydra.Class = function (api, def) {
   var self = this;
 
-  this.api = api;
-  this.iri = def['@id'];
-  this.label = def.label;
+  self.api = api;
+  self.iri = def['@id'];
+  _.extend(self, def)
 
-  this.init = function () {
+  self.init = function () {
     return Promise.resolve().then(function () {
       self.operations = utils.toArray(def.supportedOperation).map(function (operationDef) {
         return self.api.findOperation(operationDef['@id']);
@@ -179,7 +179,7 @@ hydra.Class = function (api, def) {
     });
   };
 
-  this.validate = hydra.defaults.validateClass;
+  self.validate = hydra.defaults.validateClass;
 };
 
 
@@ -208,11 +208,11 @@ hydra.ClassDocument = function (document, abstract, def) {
 hydra.Operation = function (api, def) {
   var self = this;
 
-  this.api = api;
-  this.iri = def['@id'];
-  this.label = def.label;
+  self.api = api;
+  self.iri = def['@id'];
+  _.extend(self, def)
 
-  this.init = function () {
+  self.init = function () {
     return Promise.resolve().then(function () {
       self.method = def.method;
       self.statusCodes = def.statusCodes;
@@ -242,19 +242,16 @@ hydra.OperationDocument = function (document, abstract, def) {
 hydra.Property = function (api, def) {
   var self = this;
 
-  this.api = api;
-  this.iri = utils.iri(def.property);
-  this.title = def.title;
-  this.description = def.description;
-  this.label = def.label;
-  this.readonly = def.readonly;
-  this.writeonly = def.writeonly;
-  this.operations = utils.toArray(def.property.supportedOperation)
+  self.api = api;
+  self.iri = utils.iri(def.property);
+  _.extend(self, def)
+
+  self.operations = utils.toArray(def.property.supportedOperation)
     .map(function (operationDef) {
       return self.api.findOperation(utils.iri(operationDef));
     });
 
-  this.findOperation = _.find.bind(null, this.operations, 'method');
+  self.findOperation = _.find.bind(null, self.operations, 'method');
 };
 
 


### PR DESCRIPTION
Simplify copying attributes from the definition to the class instance and
support custom properties.
